### PR TITLE
Focus camera on voxel

### DIFF
--- a/game/src/interface/gui/HUD.cpp
+++ b/game/src/interface/gui/HUD.cpp
@@ -64,7 +64,7 @@ void HUD::displayTooltip(const char * text) {
     strcpy(tooltip, text);
 }
 
-void HUD::update_controls() {
+void HUD::update_controls(RenderCamera &render_camera, const BrushRenderer &brush_renderer) {
     // This updates cube controls and textures
     cube.update();
 
@@ -82,6 +82,10 @@ void HUD::update_controls() {
     if (EventConsumer::ref()->isKeyPressed(KEY_H)) { // Cycle gravity
         sim->cycle_gravity_mode();
         displayTooltip(TextFormat("Gravity: %s", Simulation::getGravityModeName(sim->gravity_mode)));
+        consumeKey = true;
+    }
+    if (EventConsumer::ref()->isKeyPressed(KEY_F)) {
+        render_camera.setLerpTarget(render_camera.camera.position, (Vector3)brush_renderer.get_raycast_pos(), render_camera.camera.up);
         consumeKey = true;
     }
 

--- a/game/src/interface/gui/HUD.h
+++ b/game/src/interface/gui/HUD.h
@@ -52,7 +52,7 @@ public:
     void displayTooltip(const char * text);
 
     void init(); // called after OpenGL instance is initialized
-    void update_controls();
+    void update_controls(RenderCamera &render_camera, const BrushRenderer &brush_renderer);
     void draw(const HUDData &data);
     void setState(HUDState state) { this->state = state; }
 };

--- a/game/src/screen_gameplay.cpp
+++ b/game/src/screen_gameplay.cpp
@@ -192,7 +192,7 @@ void ScreenGameplay::draw() {
     FrameTime::ref()->update();
     EventConsumer::ref()->reset();
 
-    hud.update_controls();
+    hud.update_controls(render_camera, brush_renderer);
     brush_renderer.update();
     render_camera.update();
 

--- a/game/src/util/vector_op.h
+++ b/game/src/util/vector_op.h
@@ -207,6 +207,13 @@ public:
         z = other.z;
         return *this;
     }
+    explicit operator Vector3() const {
+        Vector3 v;
+        v.x = x;
+        v.y = y;
+        v.z = z;
+        return v;
+    }
 };
 
 template <class T> inline std::ostream& operator<<(std::ostream& os, const Vector3T<T>& vec) {


### PR DESCRIPTION
Panning is finicky. I think it would be nice if you could just select a voxel around which the camera can orbit.